### PR TITLE
feat: add support for single or multiple discord webhook urls per feed

### DIFF
--- a/cmd/brassite/main.go
+++ b/cmd/brassite/main.go
@@ -196,12 +196,14 @@ func runWorker(feed brassite.Feed) {
 			}
 
 			// Deliver to Discord
-			if feed.Delivery.DiscordWebhookUrl != "" {
-				err := brassite.DeliverToDiscord(ctx, feed.Delivery.DiscordWebhookUrl, feedItem, feed.Logo)
-				if err != nil {
-					slog.Error("Failed to deliver to Discord", slog.String("feed_name", feed.Name), slog.Any("error", err))
+			if len(feed.Delivery.DiscordWebhookUrl.Values) > 0 {
+				for _, url := range feed.Delivery.DiscordWebhookUrl.Values {
+					err := brassite.DeliverToDiscord(ctx, url, feedItem, feed.Logo)
+					if err != nil {
+						slog.Error("Failed to deliver to Discord", slog.String("feed_name", feed.Name), slog.Any("error", err))
 
-					sentry.CaptureException(err)
+						sentry.CaptureException(err)
+					}
 				}
 			}
 

--- a/configuration.go
+++ b/configuration.go
@@ -106,6 +106,25 @@ func (d *DiscordWebhookUrl) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DiscordWebhookUrl) UnmarshalTOML(data any) error {
+	multi, ok := data.([]any)
+	if ok {
+		var multiStrs []string
+		for _, item := range multi {
+			str, _ := item.(string)
+			multiStrs = append(multiStrs, str)
+		}
+		d.Values = multiStrs
+		return nil
+	} else if single, ok := data.(string); ok {
+		d.Values = make([]string, 1)
+		d.Values[0] = single
+		return nil
+	}
+
+	return fmt.Errorf("provided %T, expected string or []string", data)
+}
+
 func ParseConfiguration(configPath string) (Configuration, error) {
 	if configPath == "" {
 		return Configuration{}, fmt.Errorf("config path is empty")

--- a/configuration.go
+++ b/configuration.go
@@ -58,11 +58,35 @@ type BasicAuth struct {
 
 type Delivery struct {
 	// Discord webhook URL
-	DiscordWebhookUrl string `json:"discord_webhook_url" yaml:"discord_webhook_url" toml:"discord_webhook_url"`
+	DiscordWebhookUrl DiscordWebhookUrl `json:"discord_webhook_url" yaml:"discord_webhook_url" toml:"discord_webhook_url"`
 	// Telegram bot token
 	TelegramBotToken string `json:"telegram_bot_token" yaml:"telegram_bot_token" toml:"telegram_bot_token"`
 	// Telegram chat ID
 	TelegramChatId string `json:"telegram_chat_id" yaml:"telegram_chat_id" toml:"telegram_chat_id"`
+}
+
+type DiscordWebhookUrl struct {
+	Values []string
+}
+
+// References: https://github.com/go-yaml/yaml/issues/100
+//
+// Custom unmarshaller to support reading a field as string or array of strings
+func (d *DiscordWebhookUrl) UnmarshalYAML(unmarshal func(any) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err != nil {
+		var single string
+		err := unmarshal(&single)
+		if err != nil {
+			return err
+		}
+		d.Values = make([]string, 1)
+		d.Values[0] = single
+	} else {
+		d.Values = multi
+	}
+	return nil
 }
 
 func ParseConfiguration(configPath string) (Configuration, error) {
@@ -130,7 +154,7 @@ func (c Configuration) Validate() (ok bool, issues *ValidationError) {
 				ok = false
 			}
 		}
-		if feed.Delivery.DiscordWebhookUrl == "" && feed.Delivery.TelegramBotToken == "" {
+		if len(feed.Delivery.DiscordWebhookUrl.Values) == 0 && feed.Delivery.TelegramBotToken == "" {
 			issues.AddIssue(fmt.Sprintf("feeds.%d.delivery", i), "at least one delivery method is required (otherwise what's the point?)")
 			ok = false
 		}

--- a/configuration.go
+++ b/configuration.go
@@ -122,7 +122,7 @@ func (d *DiscordWebhookUrl) UnmarshalTOML(data any) error {
 		return nil
 	}
 
-	return fmt.Errorf("provided %T, expected string or []string", data)
+	return fmt.Errorf("the value %v is not a string or []string", data)
 }
 
 func ParseConfiguration(configPath string) (Configuration, error) {

--- a/configuration.go
+++ b/configuration.go
@@ -89,6 +89,23 @@ func (d *DiscordWebhookUrl) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
+func (d *DiscordWebhookUrl) UnmarshalJSON(data []byte) error {
+	var multi []string
+	err := json5.Unmarshal(data, &multi)
+	if err != nil {
+		var single string
+		err := json5.Unmarshal(data, &single)
+		if err != nil {
+			return err
+		}
+		d.Values = make([]string, 1)
+		d.Values[0] = single
+	} else {
+		d.Values = multi
+	}
+	return nil
+}
+
 func ParseConfiguration(configPath string) (Configuration, error) {
 	if configPath == "" {
 		return Configuration{}, fmt.Errorf("config path is empty")


### PR DESCRIPTION
## Background

I want to host Brassite to provide a few newsfeeds to several discord servers. The current config limitation means that to push the same newsfeed to multiple channels, I would need to create several feeds in the configuration with the only difference probably being the discord webhook url.

## Feature Request and Changes

I've changed the configuration struct to support arrays of strings for the webhook urls. To maintain compatibility with the previous string-only field, I've decided to implement a few simple unmarshal functions for each supported file format.

## Outcome

We can now support formats such as this

```yaml
feeds:
  - name: Lorem Ipsum
    url: http://lorem-rss.herokuapp.com/feed?unit=second&interval=30&length=3
    logo: https://www.clipartmax.com/png/middle/75-756149_big-image-generic-logo-png-transparent.png
    interval: 30s
    without_content: false
    delivery:
      discord_webhook_url:
        - https://discord.com/api/webhooks/1245420624420274249/Q7rxVwbmV6X_y-AypuevwjVPlRcjxrGvXxnB9da4dy1TNnqiCaXyUZ-AFBBiOnqeNFQ4
        - https://discord.com/api/webhooks/1245420809095352400/IU3Pg2kvAoHJ6a6LN6NFP3uqKUnWiRDh5aDVO_eQu2LYdO3y0KgILhTOgmUlwpRSSMy5
```

as well as this

```yaml
feeds:
  - name: Lorem Ipsum
    url: http://lorem-rss.herokuapp.com/feed?unit=second&interval=30&length=3
    logo: https://www.clipartmax.com/png/middle/75-756149_big-image-generic-logo-png-transparent.png
    interval: 30s
    without_content: false
    delivery:
      discord_webhook_url: https://discord.com/api/webhooks/1245420624420274249/Q7rxVwbmV6X_y-AypuevwjVPlRcjxrGvXxnB9da4dy1TNnqiCaXyUZ-AFBBiOnqeNFQ4
```